### PR TITLE
add healthcheck

### DIFF
--- a/services/frontier/internal/app.go
+++ b/services/frontier/internal/app.go
@@ -57,7 +57,7 @@ type App struct {
 	historyQ        *history.Q
 	ctx             context.Context
 	cancel          func()
-	frontierVersion  string
+	frontierVersion string
 	coreSettings    coreSettingsStore
 	orderBookStream *ingest.OrderBookStream
 	submitter       *txsub.System
@@ -89,11 +89,11 @@ func (a *App) GetCoreSettings() actions.CoreSettings {
 // NewApp constructs an new App instance from the provided config.
 func NewApp(config Config) (*App, error) {
 	a := &App{
-		config:         config,
-		ledgerState:    &ledger.State{},
+		config:          config,
+		ledgerState:     &ledger.State{},
 		frontierVersion: app.Version(),
-		ticks:          time.NewTicker(1 * time.Second),
-		done:           make(chan struct{}),
+		ticks:           time.NewTicker(1 * time.Second),
+		done:            make(chan struct{}),
 	}
 
 	if err := a.init(); err != nil {
@@ -485,8 +485,17 @@ func (a *App) init() error {
 		PathFinder:         a.paths,
 		PrometheusRegistry: a.prometheusRegistry,
 		CoreGetter:         a,
-		FrontierVersion:     a.frontierVersion,
+		FrontierVersion:    a.frontierVersion,
 		FriendbotURL:       a.config.FriendbotURL,
+		HealthCheck: healthCheck{
+			session: a.historyQ.Session,
+			ctx:     a.ctx,
+			core: &digitalbitscore.Client{
+				HTTP: &http.Client{Timeout: infoRequestTimeout},
+				URL:  a.config.DigitalBitsCoreURL,
+			},
+			cache: newHealthCache(healthCacheTTL),
+		},
 	}
 
 	var err error

--- a/services/frontier/internal/health.go
+++ b/services/frontier/internal/health.go
@@ -1,0 +1,96 @@
+package frontier
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/xdbfoundation/go/protocols/digitalbitscore"
+	"github.com/xdbfoundation/go/support/clock"
+	"github.com/xdbfoundation/go/support/db"
+	"github.com/xdbfoundation/go/support/log"
+)
+
+const (
+	dbPingTimeout      = 5 * time.Second
+	infoRequestTimeout = 5 * time.Second
+	healthCacheTTL     = 500 * time.Millisecond
+)
+
+var healthLogger = log.WithField("service", "healthCheck")
+
+type digitalbitsCoreClient interface {
+	Info(ctx context.Context) (*digitalbitscore.InfoResponse, error)
+}
+
+type healthCache struct {
+	response   healthResponse
+	lastUpdate time.Time
+	ttl        time.Duration
+	clock      clock.Clock
+	lock       sync.Mutex
+}
+
+func (h *healthCache) get(runCheck func() healthResponse) healthResponse {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	if h.clock.Now().Sub(h.lastUpdate) > h.ttl {
+		h.response = runCheck()
+		h.lastUpdate = h.clock.Now()
+	}
+
+	return h.response
+}
+
+func newHealthCache(ttl time.Duration) *healthCache {
+	return &healthCache{ttl: ttl}
+}
+
+type healthCheck struct {
+	session db.SessionInterface
+	ctx     context.Context
+	core    digitalbitsCoreClient
+	cache   *healthCache
+}
+
+type healthResponse struct {
+	DatabaseConnected bool `json:"database_connected"`
+	CoreUp            bool `json:"core_up"`
+	CoreSynced        bool `json:"core_synced"`
+}
+
+func (h healthCheck) runCheck() healthResponse {
+	response := healthResponse{
+		DatabaseConnected: true,
+		CoreUp:            true,
+		CoreSynced:        true,
+	}
+	if err := h.session.Ping(dbPingTimeout); err != nil {
+		healthLogger.Warnf("could not ping db: %s", err)
+		response.DatabaseConnected = false
+	}
+	if resp, err := h.core.Info(h.ctx); err != nil {
+		healthLogger.Warnf("request to digitalbits core failed: %s", err)
+		response.CoreUp = false
+		response.CoreSynced = false
+	} else {
+		response.CoreSynced = resp.IsSynced()
+	}
+
+	return response
+}
+
+func (h healthCheck) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	response := h.cache.get(h.runCheck)
+
+	if !response.DatabaseConnected || !response.CoreSynced || !response.CoreUp {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		healthLogger.Warnf("could not write response: %s", err)
+	}
+}

--- a/services/frontier/internal/health_test.go
+++ b/services/frontier/internal/health_test.go
@@ -1,0 +1,212 @@
+package frontier
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/xdbfoundation/go/protocols/digitalbitscore"
+	"github.com/xdbfoundation/go/support/clock"
+	"github.com/xdbfoundation/go/support/clock/clocktest"
+	"github.com/xdbfoundation/go/support/db"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+var _ digitalbitsCoreClient = (*mockDigitalBitsCore)(nil)
+
+type mockDigitalBitsCore struct {
+	mock.Mock
+}
+
+func (m *mockDigitalBitsCore) Info(ctx context.Context) (*digitalbitscore.InfoResponse, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(*digitalbitscore.InfoResponse), args.Error(1)
+}
+
+func TestHealthCheck(t *testing.T) {
+	synced := &digitalbitscore.InfoResponse{}
+	synced.Info.State = "Synced!"
+	notSynced := &digitalbitscore.InfoResponse{}
+	notSynced.Info.State = "Catching up"
+
+	for _, tc := range []struct {
+		name             string
+		pingErr          error
+		coreErr          error
+		coreResponse     *digitalbitscore.InfoResponse
+		expectedStatus   int
+		expectedResponse healthResponse
+	}{
+		{
+			"healthy",
+			nil,
+			nil,
+			synced,
+			http.StatusOK,
+			healthResponse{
+				DatabaseConnected: true,
+				CoreUp:            true,
+				CoreSynced:        true,
+			},
+		},
+		{
+			"db down",
+			fmt.Errorf("database is down"),
+			nil,
+			synced,
+			http.StatusServiceUnavailable,
+			healthResponse{
+				DatabaseConnected: false,
+				CoreUp:            true,
+				CoreSynced:        true,
+			},
+		},
+		{
+			"digitalbits core not synced",
+			nil,
+			nil,
+			notSynced,
+			http.StatusServiceUnavailable,
+			healthResponse{
+				DatabaseConnected: true,
+				CoreUp:            true,
+				CoreSynced:        false,
+			},
+		},
+		{
+			"digitalbits core down",
+			nil,
+			fmt.Errorf("digitalbits core is down"),
+			nil,
+			http.StatusServiceUnavailable,
+			healthResponse{
+				DatabaseConnected: true,
+				CoreUp:            false,
+				CoreSynced:        false,
+			},
+		},
+		{
+			"digitalbits core and db down",
+			fmt.Errorf("database is down"),
+			fmt.Errorf("digitalbits core is down"),
+			nil,
+			http.StatusServiceUnavailable,
+			healthResponse{
+				DatabaseConnected: false,
+				CoreUp:            false,
+				CoreSynced:        false,
+			},
+		},
+		{
+			"digitalbits core not synced and db down",
+			fmt.Errorf("database is down"),
+			nil,
+			notSynced,
+			http.StatusServiceUnavailable,
+			healthResponse{
+				DatabaseConnected: false,
+				CoreUp:            true,
+				CoreSynced:        false,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			session := &db.MockSession{}
+			session.On("Ping", dbPingTimeout).Return(tc.pingErr).Once()
+			ctx := context.Background()
+			core := &mockDigitalBitsCore{}
+			core.On("Info", ctx).Return(tc.coreResponse, tc.coreErr).Once()
+
+			h := healthCheck{
+				session: session,
+				ctx:     ctx,
+				core:    core,
+				cache:   newHealthCache(healthCacheTTL),
+			}
+
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, nil)
+			assert.Equal(t, tc.expectedStatus, w.Code)
+
+			var response healthResponse
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedResponse, response)
+
+			session.AssertExpectations(t)
+			core.AssertExpectations(t)
+		})
+	}
+}
+
+func TestHealthCheckCache(t *testing.T) {
+	cachedResponse := healthResponse{
+		DatabaseConnected: false,
+		CoreUp:            true,
+		CoreSynced:        false,
+	}
+	h := healthCheck{
+		session: nil,
+		ctx:     context.Background(),
+		core:    nil,
+		cache: &healthCache{
+			response:   cachedResponse,
+			lastUpdate: time.Unix(0, 0),
+			ttl:        5 * time.Second,
+			lock:       sync.Mutex{},
+		},
+	}
+
+	for _, timestamp := range []time.Time{time.Unix(1, 0), time.Unix(4, 0)} {
+		h.cache.clock = clock.Clock{
+			Source: clocktest.FixedSource(timestamp),
+		}
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, nil)
+		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+		var response healthResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, cachedResponse, response)
+		assert.Equal(t, cachedResponse, h.cache.response)
+		assert.True(t, h.cache.lastUpdate.Equal(time.Unix(0, 0)))
+	}
+
+	session := &db.MockSession{}
+	session.On("Ping", dbPingTimeout).Return(nil).Once()
+	core := &mockDigitalBitsCore{}
+	core.On("Info", h.ctx).Return(&digitalbitscore.InfoResponse{}, fmt.Errorf("core err")).Once()
+	h.session = session
+	h.core = core
+	updatedResponse := healthResponse{
+		DatabaseConnected: true,
+		CoreUp:            false,
+		CoreSynced:        false,
+	}
+	for _, timestamp := range []time.Time{time.Unix(6, 0), time.Unix(7, 0)} {
+		h.cache.clock = clock.Clock{
+			Source: clocktest.FixedSource(timestamp),
+		}
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, nil)
+		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+		var response healthResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, updatedResponse, response)
+		assert.Equal(t, updatedResponse, h.cache.response)
+		assert.True(t, h.cache.lastUpdate.Equal(time.Unix(6, 0)))
+	}
+
+	session.AssertExpectations(t)
+	core.AssertExpectations(t)
+}

--- a/services/frontier/internal/httpx/router.go
+++ b/services/frontier/internal/httpx/router.go
@@ -40,8 +40,9 @@ type RouterConfig struct {
 	PathFinder         paths.Finder
 	PrometheusRegistry *prometheus.Registry
 	CoreGetter         actions.CoreSettingsGetter
-	FrontierVersion     string
+	FrontierVersion    string
 	FriendbotURL       *url.URL
+	HealthCheck        http.Handler
 }
 
 type Router struct {
@@ -104,12 +105,14 @@ func (r *Router) addRoutes(config *RouterConfig, rateLimiter *throttled.HTTPRate
 		FrontierSession: config.DBSession,
 	}
 
+	r.Method(http.MethodGet, "/health", config.HealthCheck)
+
 	r.Method(http.MethodGet, "/", ObjectActionHandler{Action: actions.GetRootHandler{
 		LedgerState:        ledgerState,
 		CoreSettingsGetter: config.CoreGetter,
 		NetworkPassphrase:  config.NetworkPassphrase,
 		FriendbotURL:       config.FriendbotURL,
-		FrontierVersion:     config.FrontierVersion,
+		FrontierVersion:    config.FrontierVersion,
 	}})
 
 	streamHandler := sse.StreamHandler{

--- a/support/db/main.go
+++ b/support/db/main.go
@@ -123,6 +123,7 @@ type SessionInterface interface {
 	Exec(query squirrel.Sqlizer) (sql.Result, error)
 	ExecRaw(query string, args ...interface{}) (sql.Result, error)
 	NoRows(err error) bool
+	Ping(timeout time.Duration) error
 }
 
 // Table helps to build sql queries against a given table.  It logically

--- a/support/db/mock_session.go
+++ b/support/db/mock_session.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"database/sql"
+	"time"
 
 	"github.com/Masterminds/squirrel"
 	sq "github.com/Masterminds/squirrel"
@@ -86,4 +87,8 @@ func (m *MockSession) ExecRaw(query string, args ...interface{}) (sql.Result, er
 func (m *MockSession) NoRows(err error) bool {
 	args := m.Called(err)
 	return args.Get(0).(bool)
+}
+
+func (m *MockSession) Ping(timeout time.Duration) error {
+	return m.Called(timeout).Error(0)
 }

--- a/support/db/session.go
+++ b/support/db/session.go
@@ -294,6 +294,14 @@ func (s *Session) Rollback() error {
 	return err
 }
 
+// Ping verifies a connection to the database is still alive,
+// establishing a connection if necessary.
+func (s *Session) Ping(timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(s.Ctx, timeout)
+	defer cancel()
+	return s.DB.PingContext(ctx)
+}
+
 // Select runs `query`, setting the results found on `dest`.
 func (s *Session) Select(dest interface{}, query sq.Sqlizer) error {
 	sql, args, err := s.build(query)


### PR DESCRIPTION
add healthcheck path `/health` 

Checks for database connection, core node connection and sync status of core node. 

Sample response: 
```
{
    "database_connected":false,
    "core_up":true,
    "core_synced":true
}
```